### PR TITLE
Fix never clearing instance_aabbs, formatting

### DIFF
--- a/crates/bevy_pbr/src/meshlet/cull_clusters.wgsl
+++ b/crates/bevy_pbr/src/meshlet/cull_clusters.wgsl
@@ -29,7 +29,7 @@ fn cull_clusters(
     // Calculate the queue ID for this thread
     let dispatch_id = local_invocation_index + 128u * dot(workgroup_id, vec3(num_workgroups.x * num_workgroups.x, num_workgroups.x, 1u));
     if dispatch_id >= meshlet_meshlet_cull_count_read { return; }
-    
+
 #ifdef MESHLET_FIRST_CULLING_PASS
     let meshlet_id = dispatch_id;
 #else
@@ -52,7 +52,7 @@ fn cull_clusters(
     // If we pass, try occlusion culling
     // If this node was occluded, push it's children to the second pass to check against this frame's HZB
     if should_occlusion_cull_aabb(aabb, instance_id) {
-#ifdef MESHLET_FIRST_CULLING_PASS            
+#ifdef MESHLET_FIRST_CULLING_PASS
         let id = atomicAdd(&meshlet_meshlet_cull_count_write, 1u);
         let value = InstancedOffset(instance_id, instanced_offset.offset);
         meshlet_meshlet_cull_queue[constants.rightmost_slot - id] = value;

--- a/crates/bevy_pbr/src/meshlet/cull_instances.wgsl
+++ b/crates/bevy_pbr/src/meshlet/cull_instances.wgsl
@@ -48,7 +48,7 @@ fn cull_instances(
     // Calculate the instance ID for this thread
     let dispatch_id = local_invocation_index + 128u * dot(workgroup_id, vec3(num_workgroups.x * num_workgroups.x, num_workgroups.x, 1u));
     if dispatch_id >= instance_count() { return; }
-    
+
     let instance_id = map_instance_id(dispatch_id);
     let aabb = meshlet_instance_aabbs[instance_id];
 

--- a/crates/bevy_pbr/src/meshlet/instance_manager.rs
+++ b/crates/bevy_pbr/src/meshlet/instance_manager.rs
@@ -172,6 +172,7 @@ impl InstanceManager {
 
         self.instances.clear();
         self.instance_uniforms.get_mut().clear();
+        self.instance_aabbs.get_mut().clear();
         self.instance_material_ids.get_mut().clear();
         self.instance_bvh_root_nodes.get_mut().clear();
         self.view_instance_visibility

--- a/crates/bevy_pbr/src/meshlet/meshlet_bindings.wgsl
+++ b/crates/bevy_pbr/src/meshlet/meshlet_bindings.wgsl
@@ -9,6 +9,7 @@ struct BvhNode {
     aabbs: array<MeshletAabbErrorOffset, 8>,
     lod_bounds: array<vec4<f32>, 8>,
     child_counts: array<u32, 2>,
+    _padding: vec2<u32>,
 }
 
 struct Meshlet {


### PR DESCRIPTION
Other problems I didn't fix:

`meshlet_raster_clusters` is appended to based on the per-view hardware/software raster args, but:
  1. This is overwritten by different views
  2. This might (not sure) be overwritten by the second pass within a view.
  
Once you append to `meshlet_raster_clusters`, you should never touch overwrite it until the frame ends. You need a global counter.

LOD selection logic seems broken. If I set `lod_error_is_imperceptible` to return `simplification_error == 0.0`, I expect it to render the base mesh, but it renders nothing.